### PR TITLE
Fix re-entrant lock panic in glk_window_set_arrangement

### DIFF
--- a/remglk/src/glkapi/mod.rs
+++ b/remglk/src/glkapi/mod.rs
@@ -1061,20 +1061,24 @@ where S: Default + GlkSystem {
         if let WindowData::Pair(data) = &mut win.data {
             // Check the keywin is valid
             if let Some(keywin_glkobj) = keywin {
-                let keywin = lock!(keywin_glkobj);
-                if keywin.wintype == WindowType::Pair {
-                    return Err(KeywinCantBePair);
+                {
+                    let keywin = lock!(keywin_glkobj);
+                    if keywin.wintype == WindowType::Pair {
+                        return Err(KeywinCantBePair);
+                    }
                 }
                 let mut win_parent = keywin_glkobj.downgrade();
                 loop {
                     if win_parent.as_ptr() == win_ptr {
                         break;
                     }
-                    let parent = Into::<GlkWindowShared>::into(&win_parent);
-                    let parent = lock!(parent);
-                    let parent = &parent.parent;
-                    if let Some(parent) = parent {
-                        win_parent = parent.clone();
+                    let parent_obj = Into::<GlkWindowShared>::into(&win_parent);
+                    let next_parent = {
+                        let parent = lock!(parent_obj);
+                        parent.parent.clone()
+                    };
+                    if let Some(next_parent) = next_parent {
+                        win_parent = next_parent;
                     }
                     else {
                         return Err(KeywinMustBeDescendant);

--- a/remglk_capi/src/glk/glkstart.h
+++ b/remglk_capi/src/glk/glkstart.h
@@ -18,6 +18,8 @@
 #ifndef GT_START_H
 #define GT_START_H
 
+#include <stddef.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/remglk_capi/src/glk/support.c
+++ b/remglk_capi/src/glk/support.c
@@ -13,6 +13,10 @@ https://github.com/curiousdannii/remglk-rs
 #include "glk.h"
 #include "support.h"
 
+#if defined(_MSC_VER) && !defined(__clang__)
+#define __builtin_unreachable() __assume(0)
+#endif
+
 gidispatch_rock_t gidispatch_get_objrock(void *obj, glui32 objclass) {
     switch (objclass) {
         case gidisp_Class_Fileref:


### PR DESCRIPTION
## Summary

`glk_window_set_arrangement` panics with `WouldBlock` (or, in one specific
build, silently invokes UB) when called with a non-NULL `keywin`. It hits
every Z-machine terp on the standard "resize the status grid" call.

## Reproducing

Build `remglk_capi` as a static lib and link any Z-machine terp against it
(I tested with bocfel from `garglk/terps/bocfel`, target
aarch64-apple-darwin). Feed it a story file with an init event; the first
`glk_window_set_arrangement` call from `init_screen` →
`close_upper_window` → `perform_upper_window_resize` panics:

```
thread '<unnamed>' panicked at remglk/src/glkapi/mod.rs:1074:34:
called `Result::unwrap()` on an `Err` value: "WouldBlock"
```

Backtrace:

```
remglk::glkapi::GlkApi<S>::glk_window_set_arrangement
_glk_window_set_arrangement
perform_upper_window_resize
update_delayed
resize_upper_window
close_upper_window
init_screen
```

## Root cause

Inside `glk_window_set_arrangement`, when keywin is provided:

```rust
let keywin = lock!(keywin_glkobj);              // (1) lock held through the loop
if keywin.wintype == WindowType::Pair { return Err(...) }
let mut win_parent = keywin_glkobj.downgrade(); // win_parent == keywin
loop {
    if win_parent.as_ptr() == win_ptr { break; } // false on first iteration
    let parent = Into::<GlkWindowShared>::into(&win_parent);
    let parent = lock!(parent);                  // (2) re-locks keywin → EBUSY → panic
    ...
}
```

`win_parent` starts as keywin's own downgrade. The break at the top of the
loop only fires if keywin == the pair window passed as `win_glkobj`, which
isn't the case for the standard "resize the status grid" call where the
pair is keywin's parent. So the first iteration tries to re-lock keywin,
which is still held above.

## Why this hasn't surfaced sooner

`lock!` is `try_lock().unwrap()`. Whether that panics on a re-entrant call
depends on the `Mutex` backend Rust's std selects for the target. Walking
the cfg ladder in `library/std/src/sys/sync/mutex/mod.rs`:

| Target | std `Mutex` backend | Re-entrant `try_lock` |
|---|---|---|
| Linux (glibc/musl) | `futex::Mutex` | returns `false` → **panics** |
| Windows 10+ | `futex::Mutex` (WaitOnAddress) | returns `false` → **panics** |
| Windows 7 | `windows7::Mutex` (SRWLock) | `TryAcquireSRWLockExclusive` false → **panics** |
| macOS / *BSD | `pthread::Mutex` (PTHREAD_MUTEX_NORMAL) | `pthread_mutex_trylock` → EBUSY → **panics** |
| Fuchsia | `fuchsia::Mutex` | non-reentrant → **panics** |
| wasm32 with `target_feature="atomics"` | `futex::Mutex` | returns `false` → **panics** |
| wasm32-unknown-unknown | `no_threads::Mutex` (Cell) | returns `false` → **panics** |
| **wasm32-unknown-emscripten without `-pthread`** | `pthread::Mutex` over emscripten stub libpthread | stub returns 0 → **silently succeeds** |

The only environment that masks the bug is single-threaded emscripten,
because emscripten's stub libpthread implements `pthread_mutex_trylock` as
a no-op that always returns success. That happens to be Emglken's only
build target, which is why Parchment hasn't tripped over this in practice.

The masking case is not actually safe: two live `MutexGuard`s on the same
`GlkObjectMetadata` produce aliasing `&mut` references, which is UB. It
hasn't visibly broken anything on the current emscripten + LLVM + Rust
combination, but a wasm build with `-pthread`, or any other Rust target,
will panic on the first Z-machine terp invocation.

## Fix

Two scope-narrowing changes:

1. Drop the keywin guard immediately after the `wintype == Pair` check —
   the lock isn't needed while walking ancestors.
2. In the parent-walk loop, hold each ancestor's guard only long enough to
   clone its `parent: Option<Weak>`, then drop the guard before reassigning
   `win_parent`. (The original code held the guard plus a borrow into it
   through the iteration's tail.)

No semantic change: same break condition, same `KeywinMustBeDescendant`
error, same traversal order.

## Verification

- aarch64-apple-darwin, bocfel + cloak.z3 (PunyInform):
  before the patch — panic at startup, no JSON produced;
  after the patch — full game playable, status grid renders correctly,
  RemGlk JSON output matches expectations.
- Other targets in the table above are reasoned from the std source rather
  than tested directly; happy to verify any specific one if useful.
- `cargo test` continues to pass.

I haven't added a regression test because the existing harness exercises
only glulxe and the bug requires a Z-machine-style status-window pair plus
a non-NULL keywin in `set_arrangement`. Happy to add one if you'd like —
suggestions on the simplest fixture welcome.
