### PR TITLE
Add support for `glk_style_measure`

### DIFF
--- a/remglk/src/glkapi/mod.rs
+++ b/remglk/src/glkapi/mod.rs
@@ -18,6 +18,7 @@ pub mod protocol;
 mod protocol_impl;
 mod schannels;
 mod streams;
+mod theme;
 mod windows;
 
 use std::cmp::min;
@@ -46,6 +47,7 @@ use objects::*;
 use protocol::*;
 use schannels::*;
 use streams::*;
+use theme::{clear_hint, measure_style, set_hint, ThemeState};
 use windows::*;
 
 // Expose for so they can be turned into pointers
@@ -79,6 +81,9 @@ where S: Default + GlkSystem {
     pub streams: GlkObjectStore<GlkStream>,
     stylehints_buffer: WindowStyles,
     stylehints_grid: WindowStyles,
+    hint_values_buffer: theme::HintMatrix,
+    hint_values_grid: theme::HintMatrix,
+    theme: ThemeState,
     support: SupportedFeatures,
     pub system: S,
     tempfile_counter: u32,
@@ -714,12 +719,15 @@ where S: Default + GlkSystem {
     }
 
     pub fn glk_stylehint_clear(&mut self, wintype: WindowType, style: u32, hint: u32) {
+        if !self.theme.stylehints_enabled {
+            return;
+        }
         if hint >= stylehint_NUMHINTS {
             return;
         }
 
         let selector = style_selector(style, hint);
-        let remove_styles = |stylehints: &mut WindowStyles| {
+        let remove_styles = |stylehints: &mut WindowStyles, hint_matrix: &mut theme::HintMatrix| {
             if stylehints.contains_key(&selector) {
                 let props = stylehints.get_mut(&selector).unwrap();
                 props.remove(stylehint_name(hint));
@@ -727,20 +735,24 @@ where S: Default + GlkSystem {
                     stylehints.remove(&selector);
                 }
             }
+            clear_hint(hint_matrix, style, hint);
         };
 
         if wintype == WindowType::All || wintype == WindowType::Buffer {
-            remove_styles(&mut self.stylehints_buffer);
+            remove_styles(&mut self.stylehints_buffer, &mut self.hint_values_buffer);
             if style == style_Normal && hint == stylehint_BackColor {
                 self.page_margin.set_stylehint(None);
             }
         }
         if wintype == WindowType::All || wintype == WindowType::Grid {
-            remove_styles(&mut self.stylehints_grid);
+            remove_styles(&mut self.stylehints_grid, &mut self.hint_values_grid);
         }
     }
 
     pub fn glk_stylehint_set(&mut self, wintype: WindowType, style: u32, hint: u32, value: i32) {
+        if !self.theme.stylehints_enabled {
+            return;
+        }
         if hint >= stylehint_NUMHINTS {
             return;
         }
@@ -758,6 +770,7 @@ where S: Default + GlkSystem {
         };
 
         let stylehints = if wintype == WindowType::Buffer {&mut self.stylehints_buffer} else {&mut self.stylehints_grid};
+        let hint_matrix = if wintype == WindowType::Buffer {&mut self.hint_values_buffer} else {&mut self.hint_values_grid};
         let selector = style_selector(style, hint);
 
         #[allow(non_upper_case_globals)]
@@ -779,10 +792,24 @@ where S: Default + GlkSystem {
 
         let props = stylehints.get_mut(&selector).unwrap();
         props.insert(stylehint_name(hint).to_string(), css_value);
+        set_hint(hint_matrix, style, hint, value);
 
         if wintype == WindowType::Buffer && style == style_Normal && hint == stylehint_BackColor {
             self.page_margin.set_stylehint(Some(value as u32));
         }
+    }
+
+    pub fn glk_style_measure(&self, win: &GlkWindow, style: u32, hint: u32) -> Option<u32> {
+        let wintype = match win.wintype {
+            WindowType::Buffer | WindowType::Grid => win.wintype,
+            _ => return None,
+        };
+        let hint_matrix = if wintype == WindowType::Buffer {
+            &self.hint_values_buffer
+        } else {
+            &self.hint_values_grid
+        };
+        measure_style(&self.theme, self.theme.stylehints_enabled, hint_matrix, wintype, style, hint)
     }
 
     pub fn glk_time_to_date_local(&self, time: &GlkTime) -> GlkDate {
@@ -1256,6 +1283,9 @@ where S: Default + GlkSystem {
         match event.data {
             EventData::Init(data) => {
                 self.metrics = normalise_metrics(*data.metrics)?;
+                if let Some(theme) = data.theme {
+                    self.theme.apply(theme);
+                }
                 for support in data.support {
                     match support.as_ref() {
                         "garglktext" => self.support.garglktext = true,
@@ -1278,6 +1308,9 @@ where S: Default + GlkSystem {
 
             EventData::Arrange(data) => {
                 self.metrics = normalise_metrics(*data.metrics)?;
+                if let Some(theme) = data.theme {
+                    self.theme.apply(theme);
+                }
                 if let Some(win) = self.root_window.as_ref() {
                     let win = Into::<GlkWindowShared>::into(win);
                     self.rearrange_window(&win, WindowBox {

--- a/remglk/src/glkapi/protocol.rs
+++ b/remglk/src/glkapi/protocol.rs
@@ -61,6 +61,7 @@ pub type PartialInputs = Option<HashMap<u32, String>>;
 #[derive(Deserialize)]
 pub struct ArrangeEvent {
     pub metrics: Box<Metrics>,
+    pub theme: Option<Theme>,
 }
 
 /** Character (single key) event */
@@ -98,6 +99,7 @@ pub struct InitEvent {
     pub support: Vec<String>,
     /** Timezone offset in minutes (UTC+10 = `600`) */
     pub tzoffset: Option<i32>,
+    pub theme: Option<Theme>,
 }
 
 /** Line (text) event */
@@ -227,6 +229,27 @@ pub struct Metrics {
     /** Spacing Y */
     pub spacingy: Option<f64>,
     pub width: f64,
+}
+
+/** Runner theme colours and font attributes for glk_style_measure */
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct Theme {
+    pub stylehints_enabled: bool,
+    pub buffer: StyleTable,
+    pub grid: StyleTable,
+}
+
+pub type StyleTable = Vec<StyleEntry>;
+
+/** Effective theme values for one Glk style before stylehint overrides */
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq)]
+pub struct StyleEntry {
+    pub fg: u32,
+    pub bg: u32,
+    pub weight: i32,
+    pub oblique: u32,
+    pub proportional: u32,
+    pub reverse: u32,
 }
 
 /** Normalised screen and font metrics */

--- a/remglk/src/glkapi/theme.rs
+++ b/remglk/src/glkapi/theme.rs
@@ -1,0 +1,268 @@
+/*
+
+Theme table and glk_style_measure support
+=========================================
+
+Copyright (c) 2026 Dannii Willis
+MIT licenced
+https://github.com/curiousdannii/remglk-rs
+
+*/
+
+use super::constants::*;
+use super::protocol::{StyleEntry, StyleTable, Theme};
+
+pub type HintMatrix = [[Option<i32>; stylehint_NUMHINTS as usize]; style_NUMSTYLES as usize];
+
+/** Runner-provided theme table used by glk_style_measure */
+#[derive(Clone, Debug, PartialEq)]
+pub struct ThemeState {
+    pub stylehints_enabled: bool,
+    buffer: [StyleEntry; style_NUMSTYLES as usize],
+    grid: [StyleEntry; style_NUMSTYLES as usize],
+}
+
+impl Default for ThemeState {
+    fn default() -> Self {
+        Self::from_light_defaults(true)
+    }
+}
+
+impl ThemeState {
+    pub fn from_light_defaults(stylehints_enabled: bool) -> Self {
+        let buffer_normal = StyleEntry {
+            fg: 0x222222,
+            bg: 0xFFFFFF,
+            weight: 0,
+            oblique: 0,
+            proportional: 1,
+            reverse: 0,
+        };
+        let grid_normal = StyleEntry {
+            fg: 0x000000,
+            bg: 0xFFFFFF,
+            weight: 0,
+            oblique: 0,
+            proportional: 0,
+            reverse: 0,
+        };
+        Self {
+            stylehints_enabled,
+            buffer: [buffer_normal; style_NUMSTYLES as usize],
+            grid: [grid_normal; style_NUMSTYLES as usize],
+        }
+    }
+
+    pub fn apply(&mut self, theme: Theme) {
+        self.stylehints_enabled = theme.stylehints_enabled;
+        self.buffer = table_to_array(theme.buffer, self.buffer[style_Normal as usize]);
+        self.grid = table_to_array(theme.grid, self.grid[style_Normal as usize]);
+    }
+
+    pub fn entry(&self, wintype: WindowType, style: u32) -> StyleEntry {
+        let table = match wintype {
+            WindowType::Buffer => &self.buffer,
+            WindowType::Grid => &self.grid,
+            _ => return self.buffer[style_Normal as usize],
+        };
+        if style < style_NUMSTYLES {
+            table[style as usize]
+        } else {
+            table[style_Normal as usize]
+        }
+    }
+
+    pub fn measure_theme(&self, wintype: WindowType, style: u32, hint: u32) -> Option<u32> {
+        if style >= style_NUMSTYLES || hint >= stylehint_NUMHINTS {
+            return None;
+        }
+
+        #[allow(non_upper_case_globals)]
+        match hint {
+            stylehint_Indentation | stylehint_ParaIndentation => Some(0),
+            stylehint_Justification => Some(stylehint_just_LeftFlush),
+            stylehint_Size => Some(1),
+            stylehint_Weight => Some(self.entry(wintype, style).weight as u32),
+            stylehint_Oblique => Some(self.entry(wintype, style).oblique),
+            stylehint_Proportional => Some(self.entry(wintype, style).proportional),
+            stylehint_TextColor => Some(self.entry(wintype, style).fg),
+            stylehint_BackColor => Some(self.entry(wintype, style).bg),
+            stylehint_ReverseColor => Some(self.entry(wintype, style).reverse),
+            _ => None,
+        }
+    }
+}
+
+fn table_to_array(table: StyleTable, fallback: StyleEntry) -> [StyleEntry; style_NUMSTYLES as usize] {
+    let mut out = [fallback; style_NUMSTYLES as usize];
+    for (i, entry) in table.into_iter().enumerate().take(style_NUMSTYLES as usize) {
+        out[i] = entry;
+    }
+    out
+}
+
+pub fn measure_style(
+    theme: &ThemeState,
+    hints_enabled: bool,
+    hint_matrix: &HintMatrix,
+    wintype: WindowType,
+    style: u32,
+    hint: u32,
+) -> Option<u32> {
+    if style >= style_NUMSTYLES || hint >= stylehint_NUMHINTS {
+        return None;
+    }
+
+    if hints_enabled {
+        if let Some(value) = hint_matrix[style as usize][hint as usize] {
+            return Some(value as u32);
+        }
+    }
+
+    theme.measure_theme(wintype, style, hint)
+}
+
+pub fn set_hint(hint_matrix: &mut HintMatrix, style: u32, hint: u32, value: i32) {
+    if style < style_NUMSTYLES && hint < stylehint_NUMHINTS {
+        hint_matrix[style as usize][hint as usize] = Some(value);
+    }
+}
+
+pub fn clear_hint(hint_matrix: &mut HintMatrix, style: u32, hint: u32) {
+    if style < style_NUMSTYLES && hint < stylehint_NUMHINTS {
+        hint_matrix[style as usize][hint as usize] = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty_hints() -> HintMatrix {
+        [[None; stylehint_NUMHINTS as usize]; style_NUMSTYLES as usize]
+    }
+
+    fn test_theme() -> ThemeState {
+        let mut theme = ThemeState::from_light_defaults(true);
+        let mut input = theme.buffer[style_Normal as usize];
+        input.fg = 0x0B4C8E;
+        theme.buffer[style_Input as usize] = input;
+        theme
+    }
+
+    #[test]
+    fn hint_round_trip_when_enabled() {
+        let theme = test_theme();
+        let mut hints = empty_hints();
+        set_hint(&mut hints, style_Normal, stylehint_TextColor, 0x123456);
+        set_hint(&mut hints, style_Normal, stylehint_BackColor, 0x654321);
+
+        assert_eq!(
+            measure_style(&theme, true, &hints, WindowType::Buffer, style_Normal, stylehint_TextColor),
+            Some(0x123456)
+        );
+        assert_eq!(
+            measure_style(&theme, true, &hints, WindowType::Buffer, style_Normal, stylehint_BackColor),
+            Some(0x654321)
+        );
+    }
+
+    #[test]
+    fn theme_wins_when_hints_disabled() {
+        let theme = test_theme();
+        let mut hints = empty_hints();
+        set_hint(&mut hints, style_Normal, stylehint_TextColor, 0x123456);
+
+        assert_eq!(
+            measure_style(&theme, false, &hints, WindowType::Buffer, style_Normal, stylehint_TextColor),
+            Some(0x222222)
+        );
+    }
+
+    #[test]
+    fn grid_vs_buffer_window_type() {
+        let mut theme = ThemeState::from_light_defaults(true);
+        theme.grid[style_Normal as usize].fg = 0xDDDDDD;
+        theme.grid[style_Normal as usize].bg = 0x111111;
+        let hints = empty_hints();
+
+        assert_eq!(
+            measure_style(&theme, true, &hints, WindowType::Grid, style_Normal, stylehint_TextColor),
+            Some(0xDDDDDD)
+        );
+        assert_eq!(
+            measure_style(&theme, true, &hints, WindowType::Grid, style_Normal, stylehint_BackColor),
+            Some(0x111111)
+        );
+    }
+
+    #[test]
+    fn per_style_theme_entry() {
+        let theme = test_theme();
+        let hints = empty_hints();
+
+        assert_eq!(
+            measure_style(&theme, true, &hints, WindowType::Buffer, style_Input, stylehint_TextColor),
+            Some(0x0B4C8E)
+        );
+    }
+
+    #[test]
+    fn non_colour_hardcoded_hints() {
+        let theme = test_theme();
+        let hints = empty_hints();
+
+        assert_eq!(
+            measure_style(&theme, true, &hints, WindowType::Buffer, style_Normal, stylehint_Indentation),
+            Some(0)
+        );
+        assert_eq!(
+            measure_style(&theme, true, &hints, WindowType::Buffer, style_Normal, stylehint_Justification),
+            Some(stylehint_just_LeftFlush)
+        );
+        assert_eq!(
+            measure_style(&theme, true, &hints, WindowType::Buffer, style_Normal, stylehint_Size),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn clear_hint_restores_theme() {
+        let theme = test_theme();
+        let mut hints = empty_hints();
+        set_hint(&mut hints, style_Normal, stylehint_TextColor, 0x123456);
+        clear_hint(&mut hints, style_Normal, stylehint_TextColor);
+
+        assert_eq!(
+            measure_style(&theme, true, &hints, WindowType::Buffer, style_Normal, stylehint_TextColor),
+            Some(0x222222)
+        );
+    }
+
+    #[test]
+    fn apply_theme_from_protocol() {
+        let mut theme = ThemeState::default();
+        theme.apply(Theme {
+            stylehints_enabled: false,
+            buffer: vec![StyleEntry {
+                fg: 0x111111,
+                bg: 0xEEEEEE,
+                weight: 0,
+                oblique: 0,
+                proportional: 1,
+                reverse: 0,
+            }],
+            grid: vec![StyleEntry {
+                fg: 0x222222,
+                bg: 0x333333,
+                weight: 0,
+                oblique: 0,
+                proportional: 0,
+                reverse: 0,
+            }],
+        });
+        assert!(!theme.stylehints_enabled);
+        assert_eq!(theme.entry(WindowType::Buffer, style_Normal).fg, 0x111111);
+        assert_eq!(theme.entry(WindowType::Grid, style_Normal).bg, 0x333333);
+    }
+}

--- a/remglk_capi/src/glkapi.rs
+++ b/remglk_capi/src/glkapi.rs
@@ -590,9 +590,17 @@ pub extern "C" fn glk_style_distinguish(_win: WindowPtr, _style1: u32, _style2: 
 }
 
 #[no_mangle]
-pub extern "C" fn glk_style_measure(_win: WindowPtr, _style: u32, _hint: u32, result_ptr: *mut u32) -> u32 {
-    write_ptr(result_ptr, 0);
-    0
+pub extern "C" fn glk_style_measure(win: WindowPtr, style: u32, hint: u32, result_ptr: *mut u32) -> u32 {
+    let win_obj = from_ptr(win, "glk_style_measure");
+    let win = lock!(win_obj);
+    let result = GLKAPI.lock().unwrap().glk_style_measure(&win, style, hint);
+    if let Some(value) = result {
+        write_ptr(result_ptr, value);
+        1
+    } else {
+        write_ptr(result_ptr, 0);
+        0
+    }
 }
 
 #[no_mangle]

--- a/remglk_capi/src/lib.rs
+++ b/remglk_capi/src/lib.rs
@@ -94,6 +94,7 @@ extern "C" fn main(argc: c_int, argv: *const *const c_char) -> c_int {
                     "timer".to_string(),
                 ],
                 tzoffset: None,
+                theme: None,
             }),
             gen: 0,
             partial: None,


### PR DESCRIPTION
Previously, we couldn't support `glk_style_measure` synchronously, because it would require an asynchronous GlkOte request.

Now, GlkOte can optionally convey a `theme`, including a foreground and background color for normal text, and info on whether stylehints are enabled or not (which could be a user preference).

With that information, updated during `arrange` events, RemGlk can keep its own matrix of stylehints and synchronously resolve `glk_style_measure` events.

(For legacy GlkOte, RemGlk keeps a default black-on-white theme.)

See also: https://github.com/curiousdannii/asyncglk/pull/48